### PR TITLE
Fixed index.html path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@ service "apache2" do
     action [:start, :enable]
 end
 
-cookbook_file "/var/www/index.html" do
+cookbook_file "/var/www/html/index.html" do
     source "index.html"
     mode "0644"
 end


### PR DESCRIPTION
Seems like the recipe's path to index.html is incorrect? On Ubuntu, by default, the Apache2 web server stores its documents in /var/www/html.